### PR TITLE
Env var are not updated after a secret update

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -726,6 +726,11 @@ The output is similar to:
 1f2d1e2e67df
 ```
 
+#### Environment variables are not updated after a secret update
+
+If a container already consumed a secret in an environment variable, secret update will not cascade update to the container.
+But if the Kubelet restarts the container, secret update will be available.
+
 ## Immutable Secrets {#secret-immutable}
 
 {{< feature-state for_k8s_version="v1.19" state="beta" >}}


### PR DESCRIPTION
Hello,

If we mention that when we consume secret as volume, as secret update trigger container volume update: https://kubernetes.io/docs/concepts/configuration/secret/#mounted-secrets-are-updated-automatically

Nothing mentions that when we consume secret value from environment a secret update will not be cascaded.

I propose to mention this.

Sylvain

I made some test here: https://github.com/scoulomb/myk8s/blob/master/Volumes/secret-doc-deep-dive.md